### PR TITLE
Python 3.8 compatibility

### DIFF
--- a/src/trino_query_parser/parser.py
+++ b/src/trino_query_parser/parser.py
@@ -1,6 +1,6 @@
 import functools
 import re
-from typing import Callable, Generic, TypeVar, Type, Iterator, Any, Union, List
+from typing import Callable, Generic, TypeVar, Type, Iterator, Any, Tuple
 
 from antlr4 import CommonTokenStream, InputStream
 from antlr4.error.ErrorListener import ConsoleErrorListener
@@ -55,7 +55,7 @@ F = TypeVar("F", bound=Callable)
 
 
 class OverrideMethods(Generic[F]):
-    def __init__(self, methods: Iterator[tuple[str, Callable]]):
+    def __init__(self, methods: Iterator[Tuple[str, Callable]]):
         self.methods = methods
 
     def __call__(self, cls: Type):


### PR DESCRIPTION
Update the annotation hint so it is compatible with a lower version (python 3.8)

I tested locally with Python 3.8.13

```
python3.8
Python 3.8.13 (default, Jul  5 2023, 22:29:30)
[Clang 14.0.3 (clang-1403.0.22.14.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import src.trino_query_parser
```
I now can import it with no error

Issue: https://github.com/grihabor/trino-query-parser/issues/1